### PR TITLE
Libraries shouldn't make assumptions about application properties

### DIFF
--- a/safetynetlib/src/main/AndroidManifest.xml
+++ b/safetynetlib/src/main/AndroidManifest.xml
@@ -4,10 +4,6 @@
     <!-- The AndroidDeviceVerifier requires INTERNET to verfiy the response from SafetyNet -->
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
+    <application />
 
 </manifest>


### PR DESCRIPTION
A library intended to be used by other people probably shouldn't make assumptions about `application` properties for the users. Setting `android:label` and `android:allowBackup` might cause Gradle to exhibit manifest merger failures if the values are different and the user doesn't override them with [Merge Rule Markers](https://developer.android.com/studio/build/manifest-merge.html#merge_rule_markers). According to  [this](http://stackoverflow.com/questions/28157981/does-an-android-library-need-a-manifest-app-name-icon) StackOverflow answer, a library can get away without setting any of the properties.

Generally, setting `android:label` is not an issue because every auto-generated manifest file will use `@string/app_name` as the default value for `android:label`, but it is possible for users to opt to use a different string here, as was the case for me (I was using `@string/app_name_web`).

    Error:Execution failed for task ':app:processWebviewDebugManifest'.
    > Manifest merger failed : Attribute application@label value=(@string/app_name_web) from AndroidManifest.xml:22:9-35
    	is also present at [com.github.scottyab:safetynethelper:0.2.0] AndroidManifest.xml:16:9-41 value=(@string/app_name).
    	Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:5:5-20:19 to override.

I made this change so I could use the library myself and it appears to successfully deploy and build using JitPack in my project.