### PR TITLE
Add `queries` to sample app's manifest

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
     android:name="android.hardware.sensor"
     android:required="false" />
 
+  <queries>
+    <package android:name="com.android.vending" />
+  </queries>
+
   <application
     android:allowBackup="true"
     android:banner="@drawable/tv_banner"


### PR DESCRIPTION
When app is installed via Android Studio, queries
does not contain com.android.vending thus we get
"GooglePlayServices is not available on this device"
error message.

This issue only affects devices running Android R or newer.